### PR TITLE
Add comments to common parameters

### DIFF
--- a/maxscale_jobs/build.yaml
+++ b/maxscale_jobs/build.yaml
@@ -8,6 +8,7 @@
           name: box
           choices:
             !include: './maxscale_jobs/include/boxes.yaml'
+          description: 'MaxScale OS'
       - !include: './maxscale_jobs/include/target.yaml'
       - !include: './maxscale_jobs/include/remove_strip.yaml'
       - !include: './maxscale_jobs/include/cmake_flags.yaml'

--- a/maxscale_jobs/include/cmake_flags.yaml
+++ b/maxscale_jobs/include/cmake_flags.yaml
@@ -1,3 +1,4 @@
 string:
   name: cmake_flags
   default: !include: './maxscale_jobs/include/default_cmake_debug.yaml'
+  description: 'Command line flags given to CMake when MaxScale is being configured'

--- a/maxscale_jobs/include/name.yaml
+++ b/maxscale_jobs/include/name.yaml
@@ -1,3 +1,4 @@
 string:
    name: name
    default: !include: './maxscale_jobs/include/default_run_test_name.yaml'
+   description: 'Name of this build'

--- a/maxscale_jobs/include/source.yaml
+++ b/maxscale_jobs/include/source.yaml
@@ -4,3 +4,4 @@ choice:
     - BRANCH
     - TAG
     - COMMIT
+  description: 'The source type to use'

--- a/maxscale_jobs/include/target.yaml
+++ b/maxscale_jobs/include/target.yaml
@@ -1,3 +1,4 @@
 string:
   name: target
   default: !include: './maxscale_jobs/include/default_target.yaml'
+  description: 'The repository sub-directory where packages are stored'

--- a/maxscale_jobs/include/test_set.yaml
+++ b/maxscale_jobs/include/test_set.yaml
@@ -1,3 +1,4 @@
 string:
   name: test_set
   default: !include: './maxscale_jobs/include/default_test_set.yaml'
+  description: 'Command line parameters given to CTest'

--- a/maxscale_jobs/include/value.yaml
+++ b/maxscale_jobs/include/value.yaml
@@ -1,3 +1,4 @@
 string:
   name: value
   default: !include: './maxscale_jobs/include/default_branch.yaml'
+  description: 'The value of SOURCE'


### PR DESCRIPTION
Having comments on the parameters makes it easier to understand the build
system.