### PR TITLE
Don't run unstable tests by default

### DIFF
--- a/maxscale_jobs/include/default_test_set.yaml
+++ b/maxscale_jobs/include/default_test_set.yaml
@@ -1,1 +1,1 @@
-'-LE HEAVY'
+'-LE HEAVY\|UNSTABLE'


### PR DESCRIPTION
When unstable tests are run with stable tests, the interpretation of the
test results will take longer. Disabling them will move the test interpretation
to a more binary direction; either the test run passed or failed.