### PR TITLE
Skip unstable tests in daily runs

### DIFF
--- a/maxscale_jobs/daily_heavy_run_test.yaml
+++ b/maxscale_jobs/daily_heavy_run_test.yaml
@@ -7,7 +7,7 @@
       - trigger-builds:
           - project: 'build_and_test'
             predefined-parameters: |
-              test_set=
+              test_set=-LE UNSTABLE
               smoke=yes
               name=daily_all-$BUILD_ID
               target=daily_all-$BUILD_ID 


### PR DESCRIPTION
The tests labeled with the UNSTABLE label should not be run.