### PR TITLE
Run only one build_and_test at a time

### DIFF
--- a/maxscale_jobs/build_and_test.yaml
+++ b/maxscale_jobs/build_and_test.yaml
@@ -48,4 +48,4 @@
             current-parameters: true
     wrappers:
       - !include: './maxscale_jobs/include/workspace-cleanup.yaml'
-    concurrent: true
+    concurrent: false


### PR DESCRIPTION
Running multiple tests at a time does not give deterministic test results.