### PR TITLE
Run test matrix in series

### DIFF
--- a/maxscale_jobs/run_test_matrix.yaml
+++ b/maxscale_jobs/run_test_matrix.yaml
@@ -56,5 +56,4 @@
       - !include: './maxscale_jobs/include/build_parser_mail.yaml'
     wrappers:
       - !include: './maxscale_jobs/include/workspace-cleanup.yaml'
-    concurrent: true
 


### PR DESCRIPTION
Running parallel tests isn't good for the stability of the test results as they depend on timeouts.