### PR TITLE
Prevent concurrent build_and_test jobs

### DIFF
--- a/maxscale_jobs/build_and_test.yaml
+++ b/maxscale_jobs/build_and_test.yaml
@@ -25,7 +25,7 @@
     properties:
       - throttle:
           option: project
-          max-per-node: 5
+          max-per-node: 1
           max-total: 25
           enabled: true
     builders:


### PR DESCRIPTION
The limitation for build_and_test jobs per node should be one.